### PR TITLE
Ensure controller ignores AWS tags

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-02-06T03:12:52Z"
-  build_hash: 8762917215d9902b2011a2b0b1b0c776855a683e
+  build_date: "2025-02-10T22:13:29Z"
+  build_hash: 6b76870d01053515da416a64571b6af7cad75a66
   go_version: go1.23.5
-  version: v0.42.0
+  version: v0.42.0-1-g6b76870
 api_directory_checksum: 78c2eb5f2e05080726633beb066d0b258bf2c290
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/efs-controller
-  newTag: 1.0.4
+  newTag: 1.0.3

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/michaelhtm/ack-runtime v0.42.1-0.20250210220826-e83551905903

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/aws-controllers-k8s/ec2-controller v1.2.2 h1:ek/cGd76XTWQXe6185nxrmEm
 github.com/aws-controllers-k8s/ec2-controller v1.2.2/go.mod h1:4e2L1aHo1fk3ihVTRmnhA6VJ2NSSoYPEf1GZNYYPwLw=
 github.com/aws-controllers-k8s/kms-controller v1.0.9 h1:GZHSnuZBoWp9r6RaJ3siyDn5BRhDuaZJXtdBKeAiLSw=
 github.com/aws-controllers-k8s/kms-controller v1.0.9/go.mod h1:Pnz0d5sly7dUgmYMDJWSRIKASOujJFi/b8N2q1qCLqU=
-github.com/aws-controllers-k8s/runtime v0.42.0 h1:fVb3cOwUtn0ZwTSedapES+Rspb97S8BTxMqXJt6R5uM=
-github.com/aws-controllers-k8s/runtime v0.42.0/go.mod h1:Oy0JKvDxZMZ+SVupm4NZVqP00KLIIAMfk93KnOwlt5c=
 github.com/aws/aws-sdk-go v1.49.24 h1:2ekq9ZvaoB2aRbTDfARzgVGUBB9N8XD2QYhFmTBlp+c=
 github.com/aws/aws-sdk-go v1.49.24/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -114,6 +112,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/michaelhtm/ack-runtime v0.42.1-0.20250210220826-e83551905903 h1:HocCb4NO9ccoPKzUMrpPvV0dliiJoWs8cmUbis9xyxo=
+github.com/michaelhtm/ack-runtime v0.42.1-0.20250210220826-e83551905903/go.mod h1:Oy0JKvDxZMZ+SVupm4NZVqP00KLIIAMfk93KnOwlt5c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: efs-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic File System (EFS)
-version: 1.0.4
-appVersion: 1.0.4
+version: 1.0.3
+appVersion: 1.0.3
 home: https://github.com/aws-controllers-k8s/efs-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/efs-controller:1.0.4".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/efs-controller:1.0.3".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/efs-controller
-  tag: 1.0.4
+  tag: 1.0.3
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/file_system/hooks.go
+++ b/pkg/resource/file_system/hooks.go
@@ -242,12 +242,19 @@ func (rm *resourceManager) syncBackupPolicy(ctx context.Context, r *resource) (e
 	exit := rlog.Trace("rm.syncBackupPolicy")
 	defer func() { exit(err) }()
 
+	status := svcsdktypes.StatusDisabled
+	if r.ko.Spec.BackupPolicy != nil && r.ko.Spec.BackupPolicy.Status != nil {
+		status = svcsdktypes.Status(*r.ko.Spec.BackupPolicy.Status)
+	} else if r.ko.Spec.Backup != nil && *r.ko.Spec.Backup {
+		status = svcsdktypes.StatusEnabled
+	}
+
 	_, err = rm.sdkapi.PutBackupPolicy(
 		ctx,
 		&svcsdk.PutBackupPolicyInput{
 			FileSystemId: r.ko.Status.FileSystemID,
 			BackupPolicy: &svcsdktypes.BackupPolicy{
-				Status: svcsdktypes.Status(*r.ko.Spec.BackupPolicy.Status),
+				Status: status,
 			},
 		},
 	)

--- a/pkg/resource/file_system/sdk.go
+++ b/pkg/resource/file_system/sdk.go
@@ -391,6 +391,10 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// TODO(michaelhtm):Make sure to add custom code if this works
+	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
+		return nil, err
+	}
 	// We expect the fs to be in 'creating' status since we just issued
 	// the call to create it, but I suppose it doesn't hurt to check here.
 	if filesystemCreating(&resource{ko}) {

--- a/pkg/resource/mount_target/manager.go
+++ b/pkg/resource/mount_target/manager.go
@@ -102,6 +102,7 @@ func (rm *resourceManager) ReadOne(
 		panic("resource manager's ReadOne() method received resource with nil CR object")
 	}
 	observed, err := rm.sdkFind(ctx, r)
+	filterAWSTags(observed)
 	if err != nil {
 		if observed != nil {
 			return rm.onError(observed, err)
@@ -284,6 +285,16 @@ func (rm *resourceManager) EnsureTags(
 ) error {
 
 	return nil
+}
+
+// filterAWSTags ignores tags that have keys that start with "aws:"
+// is needed to ensure the controller does not attempt to remove
+// tags set by AWS. This function needs to be called after each Read
+// operation.
+// Eg. resources created with cloudformation have tags that cannot be
+// removed by an ACK controller
+func filterAWSTags(r *resource) {
+
 }
 
 // newResourceManager returns a new struct implementing

--- a/test/e2e/resources/file_system_backup.yaml
+++ b/test/e2e/resources/file_system_backup.yaml
@@ -8,3 +8,4 @@ spec:
     replicationOverwriteProtection: ENABLED
   performanceMode: generalPurpose
   throughputMode: bursting
+  backup: true

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -93,3 +93,10 @@ class EFSValidator:
         
     def access_point_exists(self, access_point_id) -> bool:
         return self.get_access_point(access_point_id) is not None
+    
+    def list_tags_for_resource(self, resource_id) -> list:
+        try:
+            resp = self.efs_client.list_tags_for_resource(ResourceId=resource_id)
+            return resp["Tags"]
+        except Exception as e:
+            return None

--- a/test/e2e/tests/test_access_point.py
+++ b/test/e2e/tests/test_access_point.py
@@ -32,7 +32,7 @@ RESOURCE_PLURAL = "accesspoints"
 CREATE_WAIT_AFTER_SECONDS = 15
 DELETE_WAIT_AFTER_SECONDS = 15
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def simple_access_point(efs_client, simple_file_system):
     (_, cr, file_system_id) = simple_file_system
 

--- a/test/e2e/tests/test_mount_target.py
+++ b/test/e2e/tests/test_mount_target.py
@@ -34,7 +34,7 @@ CREATE_WAIT_AFTER_SECONDS = 100
 UPDATE_WAIT_AFTER_SECONDS = 15
 DELETE_WAIT_AFTER_SECONDS = 30
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def simple_mount_target(efs_client, simple_file_system):
     (_, cr, file_system_id) = simple_file_system
 


### PR DESCRIPTION
Issue [#2182](https://github.com/aws-controllers-k8s/community/issues/2182):

Description of changes:
Adding e2e test to ensure the controller ignores tags injected by 
AWS, to prevent unallowed tag removal operations.

Also adding custom code to prevent panic for PutBackupPolicy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
