### PR TITLE
remove getImmutableFieldChanges references

### DIFF
--- a/pkg/resource/access_point/hooks.go
+++ b/pkg/resource/access_point/hooks.go
@@ -17,11 +17,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-	"github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -77,10 +75,6 @@ func (rm *resourceManager) customUpdateAccessPoint(
 	exit := rlog.Trace("rm.sdkUpdate")
 	defer func() { exit(err) }()
 
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, errors.NewTerminalError(fmt.Errorf(msg))
-	}
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics,


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
