### PR TITLE
fix: ensure we check the latest resource for status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-03-27T16:36:00Z"
-  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
+  build_date: "2025-04-11T22:07:51Z"
+  build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
   go_version: go1.24.1
-  version: v0.44.0
+  version: v0.44.0-3-g0909e7f
 api_directory_checksum: ebeb6f826282ad9134ca78efd74dc9125898fddf
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -58,8 +58,6 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_update_post_request:
         code: return desired, nil
-      sdk_create_post_set_output:
-        template_path: hooks/file_system/sdk_create_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/file_system/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -58,8 +58,6 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_update_post_request:
         code: return desired, nil
-      sdk_create_post_set_output:
-        template_path: hooks/file_system/sdk_create_post_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/file_system/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/pkg/resource/file_system/hooks.go
+++ b/pkg/resource/file_system/hooks.go
@@ -82,7 +82,7 @@ func filesystemActive(r *resource) bool {
 		return false
 	}
 	cs := *r.ko.Status.LifeCycleState
-	lifeCycleState := string(svcapitypes.LifeCycleState_available)
+	lifeCycleState := string(svcsdktypes.LifeCycleStateAvailable)
 	return cs == lifeCycleState
 }
 

--- a/pkg/resource/file_system/sdk.go
+++ b/pkg/resource/file_system/sdk.go
@@ -220,7 +220,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 	if !filesystemActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(r)
+		return &resource{ko}, requeueWaitState(&resource{ko})
 	}
 
 	return &resource{ko}, nil
@@ -395,15 +395,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	// We expect the fs to be in 'creating' status since we just issued
-	// the call to create it, but I suppose it doesn't hurt to check here.
-	if filesystemCreating(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
-	}
-
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/file_system/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/file_system/sdk_create_post_set_output.go.tpl
@@ -1,8 +1,0 @@
-	// We expect the fs to be in 'creating' status since we just issued
-	// the call to create it, but I suppose it doesn't hurt to check here.
-	if filesystemCreating(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
-	}

--- a/templates/hooks/file_system/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/file_system/sdk_read_many_post_set_output.go.tpl
@@ -2,5 +2,5 @@
 		return nil, err
 	}
 	if !filesystemActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(r)
+		return &resource{ko}, requeueWaitState(&resource{ko})
 	}


### PR DESCRIPTION
Issue [#2180](https://github.com/aws-controllers-k8s/community/issues/2180)

Description of changes:
Currently we have been checking the desired status in post_set_output. 
At that point the desired resource will not have been updated with the 
latest Status from the describe output, leading the controller to be in 
an endless reconciliation loop

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
