### PR TITLE
fix: ensure Filesystem resource is synced when available

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-05-02T16:48:14Z"
+  build_date: "2025-05-12T15:59:02Z"
   build_hash: f8dc5330705b3752ce07dce0ac831161fd4cb14f
-  go_version: go1.24.2
+  go_version: go1.24.3
   version: v0.45.0
 api_directory_checksum: ebeb6f826282ad9134ca78efd74dc9125898fddf
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 99053458e09d8c915086d82f2f76c55d6374efef
+  file_checksum: 8f51ccb0fdf00c0900f3cd0641fe851d5909686e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -56,8 +56,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
-      sdk_update_post_request:
-        code: return desired, nil
+      sdk_update_pre_set_output:
+        template_path: hooks/file_system/sdk_update_pre_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/file_system/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -56,8 +56,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
-      sdk_update_post_request:
-        code: return desired, nil
+      sdk_update_pre_set_output:
+        template_path: hooks/file_system/sdk_update_pre_set_output.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/file_system/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/pkg/resource/file_system/hooks.go
+++ b/pkg/resource/file_system/hooks.go
@@ -224,10 +224,6 @@ func (rm *resourceManager) syncPolicy(ctx context.Context, r *resource) (err err
 	exit := rlog.Trace("rm.syncPolicy")
 	defer func() { exit(err) }()
 
-	if r.ko.Spec.Policy == nil {
-		return nil
-	}
-
 	_, err = rm.sdkapi.PutFileSystemPolicy(
 		ctx,
 		&svcsdk.PutFileSystemPolicyInput{

--- a/pkg/resource/file_system/hooks.go
+++ b/pkg/resource/file_system/hooks.go
@@ -56,7 +56,7 @@ func requeueWaitState(r *resource) *ackrequeue.RequeueNeededAfter {
 	return ackrequeue.NeededAfter(
 		fmt.Errorf("filesystem in '%s' state, requeuing until filesystem is '%s'",
 			status, svcapitypes.LifeCycleState_available),
-		time.Second*10,
+		time.Second*3,
 	)
 }
 
@@ -223,6 +223,10 @@ func (rm *resourceManager) syncPolicy(ctx context.Context, r *resource) (err err
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.syncPolicy")
 	defer func() { exit(err) }()
+
+	if r.ko.Spec.Policy == nil {
+		return nil
+	}
 
 	_, err = rm.sdkapi.PutFileSystemPolicy(
 		ctx,

--- a/pkg/resource/file_system/sdk.go
+++ b/pkg/resource/file_system/sdk.go
@@ -456,6 +456,9 @@ func (rm *resourceManager) sdkUpdate(
 		exit(err)
 	}()
 	res := desired.ko.DeepCopy()
+	// This step Will ensure that the latest Status
+	// is patched into k8s, and user will be able
+	// to see the latest efs filesystem Status
 	res.Status = latest.ko.Status
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(

--- a/templates/hooks/file_system/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/file_system/sdk_update_pre_build_request.go.tpl
@@ -1,4 +1,7 @@
 	res := desired.ko.DeepCopy()
+	// This step Will ensure that the latest Status
+	// is patched into k8s, and user will be able
+	// to see the latest efs filesystem Status
 	res.Status = latest.ko.Status
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(

--- a/templates/hooks/file_system/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/file_system/sdk_update_pre_build_request.go.tpl
@@ -1,40 +1,41 @@
-
+	res := desired.ko.DeepCopy()
+	res.Status = latest.ko.Status
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
-			ctx, rm.sdkapi, rm.metrics, 
-			string(*desired.ko.Status.ACKResourceMetadata.ARN), 
+			ctx, rm.sdkapi, rm.metrics,
+			string(*desired.ko.Status.ACKResourceMetadata.ARN),
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {
-			return nil, err
+			return &resource{res}, err
 		}
 	}
 	if delta.DifferentAt("Spec.Policy") {
 		err := rm.syncPolicy(ctx, desired)
 		if err != nil {
-			return nil, err
+			return &resource{res}, err
 		}
 	}
 	if delta.DifferentAt("Spec.BackupPolicy") {
 		err := rm.syncBackupPolicy(ctx, desired)
 		if err != nil {
-			return nil, err
+			return &resource{res}, err
 		}
 	}
 	if delta.DifferentAt("Spec.LifecyclePolicies") {
 		err := rm.syncLifecyclePolicies(ctx, desired)
 		if err != nil {
-			return nil, err
+			return &resource{res}, err
 		}
 	}
 	if delta.DifferentAt("Spec.FileSystemProtection") {
 		err := rm.syncFilesystemProtection(ctx, desired)
 		if err != nil {
-			return nil, err
+			return &resource{res}, err
 		}
 	}
 	// To trigger to normal update we need to make sure that at least
 	// one of the following fields are different.
-    if !delta.DifferentAt("Spec.ProvisionedThroughputInMiBps") && !delta.DifferentAt("Spec.ThroughputMode") {
-        return desired, nil
-    }
+	if !delta.DifferentAt("Spec.ProvisionedThroughputInMiBps") && !delta.DifferentAt("Spec.ThroughputMode") {
+		return &resource{res}, nil
+	}

--- a/templates/hooks/file_system/sdk_update_pre_set_output.go.tpl
+++ b/templates/hooks/file_system/sdk_update_pre_set_output.go.tpl
@@ -1,0 +1,2 @@
+	ko.Status = latest.ko.Status
+	return &resource{ko}, nil

--- a/test/e2e/tests/test_file_system.py
+++ b/test/e2e/tests/test_file_system.py
@@ -90,11 +90,12 @@ def simple_file_system(efs_client):
 class TestFileSystem:
 
     def test_create_delete(self, efs_client, simple_file_system):
-        (_, _, file_system_id) = simple_file_system
+        (ref, _, file_system_id) = simple_file_system
         assert file_system_id is not None
 
         validator = EFSValidator(efs_client)
         assert validator.file_system_exists(file_system_id)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
     
     def test_create_update_delete(self, efs_client, simple_file_system):
         (ref, _, file_system_id) = simple_file_system
@@ -116,6 +117,7 @@ class TestFileSystem:
 
         fs = validator.get_file_system(file_system_id)
         assert fs is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert fs['FileSystems'][0]['ThroughputMode'] == "elastic"
         assert fs['FileSystems'][0]['FileSystemProtection']['ReplicationOverwriteProtection'] == "DISABLED"
 
@@ -138,6 +140,7 @@ class TestFileSystem:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         observedPolicy = validator.get_file_system_policy(file_system_id)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert json.loads(policy) == json.loads(observedPolicy)
 
     def test_update_backup_policy(self, efs_client, simple_file_system):
@@ -159,6 +162,7 @@ class TestFileSystem:
 
         bp = validator.get_backup_policy(file_system_id)
         assert bp is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert bp['Status'] == "DISABLED"
 
     def test_update_lifecycle_policies(self, efs_client, simple_file_system):
@@ -168,6 +172,7 @@ class TestFileSystem:
         validator = EFSValidator(efs_client)
         assert validator.file_system_exists(file_system_id)
 
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         updates = {
             "spec": {
                 "lifecyclePolicies": [
@@ -180,6 +185,7 @@ class TestFileSystem:
 
         lfps = validator.get_file_system_lifecycle_policy(file_system_id)
         assert lfps is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert lfps[0]['TransitionToIA'] == "AFTER_30_DAYS"
     
     def test_update_tags(self, efs_client, simple_file_system):
@@ -188,6 +194,7 @@ class TestFileSystem:
 
         validator = EFSValidator(efs_client)
         assert validator.file_system_exists(file_system_id)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
 
         desired_tags = [{
             "key": "Name",
@@ -203,6 +210,7 @@ class TestFileSystem:
 
         fs = validator.get_file_system(file_system_id)
         assert fs is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         latest_tags = fs['FileSystems'][0]["Tags"]
 
         tags.assert_ack_system_tags(


### PR DESCRIPTION
Issue [#2468](https://github.com/aws-controllers-k8s/community/issues/2468)

Description of changes:
removing the following portion from generator.yaml:
```yaml
      sdk_update_post_request:
        code: return desired, nil
```
This portion was returning `desired, nil`, right after an update call was made,
without checking if the update call returned an error, nor logging the metrics call.

Instead using 
```yaml
      sdk_update_pre_set_output:
        template_path: ...
```
Which checks for update errors, logs API Metrics, and ensures ko.Status is 
latest.Status (ensuring we return the updated Status to be patched to k8s)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
