### PR TITLE
fix: delete FileSystem Policy when null

### DIFF
--- a/pkg/resource/file_system/hooks.go
+++ b/pkg/resource/file_system/hooks.go
@@ -224,6 +224,10 @@ func (rm *resourceManager) syncPolicy(ctx context.Context, r *resource) (err err
 	exit := rlog.Trace("rm.syncPolicy")
 	defer func() { exit(err) }()
 
+	if r.ko.Spec.Policy == nil {
+		return rm.deletePolicy(ctx, r)
+	}
+
 	_, err = rm.sdkapi.PutFileSystemPolicy(
 		ctx,
 		&svcsdk.PutFileSystemPolicyInput{
@@ -233,6 +237,21 @@ func (rm *resourceManager) syncPolicy(ctx context.Context, r *resource) (err err
 		},
 	)
 	rm.metrics.RecordAPICall("UPDATE", "PutFileSystemPolicy", err)
+	return err
+}
+
+func (rm *resourceManager) deletePolicy(ctx context.Context, r *resource) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.deletePolicy")
+	defer func() { exit(err) }()
+
+	_, err = rm.sdkapi.DeleteFileSystemPolicy(
+		ctx,
+		&svcsdk.DeleteFileSystemPolicyInput{
+			FileSystemId: r.ko.Status.FileSystemID,
+		},
+	)
+	rm.metrics.RecordAPICall("UPDATE", "DeleteFileSystemPolicy", err)
 	return err
 }
 

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -43,7 +43,7 @@ class EFSValidator:
 
         except Exception as e:
             logging.debug(e)
-            return None
+            return e
         
     def get_file_system_lifecycle_policy(self, filesystem_id: str) -> dict:
         try:

--- a/test/e2e/tests/test_file_system.py
+++ b/test/e2e/tests/test_file_system.py
@@ -140,6 +140,16 @@ class TestFileSystem:
         observedPolicy = validator.get_file_system_policy(file_system_id)
         assert json.loads(policy) == json.loads(observedPolicy)
 
+        updates = {
+            "spec": {
+                "policy": None
+            }
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+        observedPolicyException = validator.get_file_system_policy(file_system_id)
+        assert isinstance(observedPolicyException , efs_client.exceptions.PolicyNotFound)
+
     def test_update_backup_policy(self, efs_client, simple_file_system):
         (ref, _, file_system_id) = simple_file_system
         assert file_system_id is not None


### PR DESCRIPTION
Description of changes:
Delete File system Policy when null
Add tests ensuring Policy is deleted when removed from Spec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
