### PR TITLE
fix: ensure Synced is generated

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-05-13T04:44:50Z"
+  build_date: "2025-05-27T16:45:03Z"
   build_hash: 55bf57b2806c33a7fcd074be403f26ce3f8e58db
-  go_version: go1.24.2
+  go_version: go1.24.3
   version: v0.46.2
 api_directory_checksum: ebeb6f826282ad9134ca78efd74dc9125898fddf
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 8f51ccb0fdf00c0900f3cd0641fe851d5909686e
+  file_checksum: 68ba2404c86e1c8b1f0bd0730312a146a6c4188f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -25,6 +25,10 @@ model_name: elasticfilesystem
 controller_name: efs
 resources:
   FileSystem:
+    synced:
+      when:
+        - path: Status.LifeCycleState
+          in: [ "available" ]
     fields:
       Backup:
         compare:
@@ -107,6 +111,10 @@ resources:
         type: string
         index: 30
   MountTarget:
+    synced:
+      when:
+        - path: Status.LifeCycleState
+          in: [ "available" ]
     tags:
       ignore: true
     fields:
@@ -127,8 +135,6 @@ resources:
     update_operation:
       custom_method_name: customUpdateMountTarget
     hooks:
-      sdk_create_post_set_output:
-        template_path: hooks/mount_target/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_build_request:
         template_path: hooks/mount_target/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -25,6 +25,10 @@ model_name: elasticfilesystem
 controller_name: efs
 resources:
   FileSystem:
+    synced:
+      when:
+        - path: Status.LifeCycleState
+          in: [ "available" ]
     fields:
       Backup:
         compare:
@@ -107,6 +111,10 @@ resources:
         type: string
         index: 30
   MountTarget:
+    synced:
+      when:
+        - path: Status.LifeCycleState
+          in: [ "available" ]
     tags:
       ignore: true
     fields:
@@ -127,8 +135,6 @@ resources:
     update_operation:
       custom_method_name: customUpdateMountTarget
     hooks:
-      sdk_create_post_set_output:
-        template_path: hooks/mount_target/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_build_request:
         template_path: hooks/mount_target/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/pkg/resource/file_system/manager.go
+++ b/pkg/resource/file_system/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.LifeCycleState == nil {
+		return false, nil
+	}
+	lifeCycleStateCandidates := []string{"available"}
+	if !ackutil.InStrings(*r.ko.Status.LifeCycleState, lifeCycleStateCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/file_system/sdk.go
+++ b/pkg/resource/file_system/sdk.go
@@ -217,10 +217,7 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
-		return nil, err
-	}
-	if !filesystemActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(&resource{ko})
+		return &resource{ko}, err
 	}
 
 	return &resource{ko}, nil

--- a/pkg/resource/mount_target/hooks.go
+++ b/pkg/resource/mount_target/hooks.go
@@ -146,13 +146,18 @@ func (rm *resourceManager) customUpdateMountTarget(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkUpdate")
 	defer func() { exit(err) }()
+	updated = rm.concreteResource(desired.DeepCopy())
+	updated.SetStatus(latest)
+	if !mountTargetActive(updated) {
+		return updated, requeueWaitState(updated)
+	}
 
 	if delta.DifferentAt("Spec.SecurityGroups") {
-		err := rm.putSecurityGroups(ctx, desired)
+		err := rm.putSecurityGroups(ctx, updated)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return desired, nil
+	return updated, nil
 }

--- a/pkg/resource/mount_target/manager.go
+++ b/pkg/resource/mount_target/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.LifeCycleState == nil {
+		return false, nil
+	}
+	lifeCycleStateCandidates := []string{"available"}
+	if !ackutil.InStrings(*r.ko.Status.LifeCycleState, lifeCycleStateCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/mount_target/sdk.go
+++ b/pkg/resource/mount_target/sdk.go
@@ -150,10 +150,7 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
-		return nil, err
-	}
-	if !mountTargetActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(r)
+		return &resource{ko}, err
 	}
 
 	return &resource{ko}, nil
@@ -266,15 +263,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	// We expect the MT to be in 'creating' status since we just issued
-	// the call to create it, but I suppose it doesn't hurt to check here.
-	if mountTargetCreating(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
-	}
-
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/file_system/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/file_system/sdk_read_many_post_set_output.go.tpl
@@ -1,6 +1,3 @@
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
-		return nil, err
-	}
-	if !filesystemActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(&resource{ko})
+		return &resource{ko}, err
 	}

--- a/templates/hooks/mount_target/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/mount_target/sdk_create_post_set_output.go.tpl
@@ -1,8 +1,0 @@
-	// We expect the MT to be in 'creating' status since we just issued
-	// the call to create it, but I suppose it doesn't hurt to check here.
-	if mountTargetCreating(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
-	}

--- a/templates/hooks/mount_target/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/mount_target/sdk_read_many_post_set_output.go.tpl
@@ -1,6 +1,3 @@
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
-		return nil, err
-	}
-	if !mountTargetActive(&resource{ko}) {
-		return &resource{ko}, requeueWaitState(r)
+		return &resource{ko}, err
 	}

--- a/test/e2e/resources/mount_target.yaml
+++ b/test/e2e/resources/mount_target.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   fileSystemID: $FILE_SYSTEM_ID
   subnetID: $PRIVATE_SUBNET
-  ipAddress: $IP_ADDRESS

--- a/test/e2e/tests/test_mount_target.py
+++ b/test/e2e/tests/test_mount_target.py
@@ -43,7 +43,6 @@ def simple_mount_target(efs_client, simple_file_system):
     replacements = REPLACEMENT_VALUES.copy()
     replacements["MOUNT_TARGET_NAME"] = resource_name
     replacements["FILE_SYSTEM_ID"] = file_system_id
-    replacements["IP_ADDRESS"] = "10.0.0.100"
 
     # Load efs CR
     resource_data = load_efs_resource(
@@ -87,8 +86,12 @@ def simple_mount_target(efs_client, simple_file_system):
 @pytest.mark.canary
 class TestMountTarget:
     def test_create_delete(self, efs_client, simple_mount_target):
-        (_, _, mount_target_id) = simple_mount_target
+        (ref, _, mount_target_id) = simple_mount_target
         assert mount_target_id is not None
 
         validator = EFSValidator(efs_client)
         assert validator.mount_target_exists(mount_target_id)
+        
+        cr = k8s.get_resource(ref)
+        assert 'spec' in cr
+        assert 'ipAddress' in cr['spec']


### PR DESCRIPTION
Issue [#2496](https://github.com/aws-controllers-k8s/community/issues/2496)

Description of changes:
These changes address the following issues:
* after creating a MountTarget, the Status gets stuck in `creating`.
* the IPAddress never gets patched after a Create.

Using the gnerator.yaml `synced` feature as a fix :

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
