### PR TITLE
[efs-controller] Treat FileSystem Policy as an IAM policy document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:08:30Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
-  version: v0.60.0
+  build_date: "2026-07-02T22:17:17Z"
+  build_hash: 84c9b9904125e2182619e048d7e35d0f8700d20c
+  go_version: go1.26.0
+  version: v0.60.0-3-g84c9b99
 api_directory_checksum: bce84152d4b1ec06243e6f2277eceb15f5610ca4
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 425c737c9038e819002561009f4cb50efb34303b
+  file_checksum: f3c09fc9bea7cd76240bc82c879a1982a239c141
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -49,6 +49,7 @@ resources:
           operation: PutBackupPolicy
           path: BackupPolicy
       Policy:
+        is_iam_policy: true
         from:
           operation: PutFileSystemPolicy
           path: Policy

--- a/generator.yaml
+++ b/generator.yaml
@@ -49,6 +49,7 @@ resources:
           operation: PutBackupPolicy
           path: BackupPolicy
       Policy:
+        is_iam_policy: true
         from:
           operation: PutFileSystemPolicy
           path: Policy

--- a/pkg/resource/file_system/delta.go
+++ b/pkg/resource/file_system/delta.go
@@ -106,7 +106,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
 		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
-		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}


### PR DESCRIPTION
## Description

Mark the FileSystem `Policy` field as `is_iam_policy` in `generator.yaml`.

### Changes
- **generator.yaml**: Add `is_iam_policy: true` to the `FileSystem.Policy` field.
- **Generated code** (`pkg/resource/file_system/delta.go`): The delta comparison now uses `ackcompare.IAMPolicyDocumentEqual` instead of raw string equality.

### Why is_iam_policy (not is_document)
The EFS file system policy is a resource-based policy written in IAM policy language (`Version`, `Statement`, `Effect`, `Principal`, `Action`, `Resource`). `is_iam_policy` uses IAM-aware semantic comparison, which correctly handles statement ordering and `Action`/`Resource` expressed as a string vs an array. This prevents spurious diffs / perpetual drift when EFS returns a normalized policy document that differs only in formatting or ordering from what the user supplied.

### Testing
- `make build-controller` (SERVICE=efs, AWS_SDK_GO_VERSION=v1.34.0) succeeds
- `go build -o bin/controller ./cmd/controller` compiles cleanly
- Existing e2e `test_update_policies` already covers the Policy create/update/delete path (EFS file system policy is supported in the `us-west-2` test region)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.